### PR TITLE
Refactoring sim period

### DIFF
--- a/ecosystem.py
+++ b/ecosystem.py
@@ -147,7 +147,6 @@ def get_eater_from_loc(arr: list[Eater], loc: tuple):
 
 def sim_period(plot: Plot):
     for eater in plot.eaters:
-        # doing something in the branch
 
         if eater.state["last_mated"] > 25:
 


### PR DESCRIPTION
Changed the order of the sim_period checking. Goes through the potential mating first instead of trying to move all of the eaters that would like to move first. 
Can be seen on line 165 where `if 2 not in eater_neighbors:` was changed to `if 2 in eater_neighbors:`
This should make the code more readable and easier to track